### PR TITLE
fix bug preventing swagger docs from displaying

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ async def calculate_stats_total(stats: dict):
     return sum(stats.values())
 
 # Define routes
-@app.get("/", response_class=Jinja2Templates.TemplateResponse)
+@app.get("/")
 async def read_pokemon_form(request: Request):
     return templates.TemplateResponse("index.html", {"request": request})
 


### PR DESCRIPTION
response_class won't be applicable to a Jinja2Templates.TemplateResponse in this manner. It's interrupting FastAPI's ability to generate the OpenAPI schema.