### PR TITLE
Fix battle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-Poekmon fight simulator using FastAPI
+Pokemon fight simulator using FastAPI.
+Details (and sprites) retrieved from https://pokeapi.co/ 
+Sprites of types retrieved from https://github.com/msikma/pokesprite
+Frontend with HTML/Jinja
 
 To run, install poetry from [here](https://python-poetry.org/docs/)
 

--- a/main.py
+++ b/main.py
@@ -49,8 +49,8 @@ async def read_pokemon(request: Request, pokemon_name: str):
 
 @app.get("/battle")
 async def battle(request: Request, pokemon1_name: str, pokemon2_name: str):
-    pokemon1_stats = await get_pokemon(pokemon1_name)
-    pokemon2_stats = await get_pokemon(pokemon2_name)
+    pokemon1_stats, _, _ = await get_pokemon(pokemon1_name)
+    pokemon2_stats, _, _ = await get_pokemon(pokemon2_name)
 
     pokemon1_total = await calculate_stats_total(pokemon1_stats)
     pokemon2_total = await calculate_stats_total(pokemon2_stats)


### PR DESCRIPTION
Previously, `get_pokemon` only returned a dict, `stats`.
Now, it returns a tuple: `(stats, sprites, types)`

This was not taken into account in the `battle` endpoint, which expected a dict.
From
```python
pokemon1_stats = await get_pokemon(pokemon1_name)
pokemon2_stats = await get_pokemon(pokemon2_name)    
```

To
```python
pokemon1_stats, _, _ = await get_pokemon(pokemon1_name)
pokemon2_stats, _, _ = await get_pokemon(pokemon2_name)    
```