### PR TITLE
Get all pokemon

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 import httpx
 from logging_config import get_logger  # Adjust the import statement according to your project structure
-import os
+from typing import List
 
 # __name__ will set logger name as the file name: 'main'
 logger = get_logger(__name__)  
@@ -67,10 +67,9 @@ async def read_pokemon_form(request: Request):
     return templates.TemplateResponse("index.html", {"request": request})
 
 
-# TODO TESTING
-# Now you can use pokemon_names_list in your endpoints:
-@app.get("/list_pokemon")
-async def list_pokemon():
+# Endpoint to pass all names to HTML as JSON
+@app.get("/pokemon_names", response_model=List[str])
+async def get_pokemon_names():
     return pokemon_names_list
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,11 +9,15 @@
 
     <form id="battleForm" action="/battle" method="get">
         <label for="pokemon1_name">Pokemon 1:</label><br>
-        <input type="text" id="pokemon1_name" name="pokemon1_name">
+        <input list="pokemon_list1" type="text" id="pokemon1_name" name="pokemon1_name">
+        <datalist id="pokemon_list1"></datalist>
         <button type="button" onclick="redirectToStats('pokemon1_name')">View Stats</button><br>
+        
         <label for="pokemon2_name">Pokemon 2:</label><br>
-        <input type="text" id="pokemon2_name" name="pokemon2_name">
+        <input list="pokemon_list2" type="text" id="pokemon2_name" name="pokemon2_name">
+        <datalist id="pokemon_list2"></datalist>
         <button type="button" onclick="redirectToStats('pokemon2_name')">View Stats</button><br><br>
+        
         <input type="submit" value="Battle!">
     </form>
 
@@ -26,6 +30,23 @@
                 alert('Please enter a Pokemon name.');
             }
         }
+
+        // Fetch the pokemon names and populate the datalists
+        fetch('/pokemon_names')
+            .then(response => response.json())
+            .then(data => {
+                const list1 = document.getElementById('pokemon_list1');
+                const list2 = document.getElementById('pokemon_list2');
+                data.forEach(name => {
+                    const option1 = document.createElement('option');
+                    option1.value = name;
+                    const option2 = document.createElement('option');
+                    option2.value = name;
+                    list1.appendChild(option1);
+                    list2.appendChild(option2);
+                });
+            });
     </script>
+
 </body>
 </html>


### PR DESCRIPTION
Address https://github.com/LAMaglan/PokeFightSimulator/issues/24, i.e. autocomplete input pokemon name fields

First commit https://github.com/LAMaglan/PokeFightSimulator/commit/1ff7476536767e0451bd015eb294191ac119dc04
 fetches all pokemon names (from pokeapi) on startup of FastAPI app, and makes it available globally.

Second commit https://github.com/LAMaglan/PokeFightSimulator/commit/d6ce0dab76633ca55585581e66f74a5dca43a04e creates new endpoint that turns it to JSON which can then be passed to client side (in this case, index.html). The form fields are now lists and made to "datalist" which can be populated. Specifically, the datalists are populated with javascript code.