### PR TITLE
improve fight logic with base stats

### DIFF
--- a/templates/battle.html
+++ b/templates/battle.html
@@ -13,13 +13,11 @@
         <div class="pokemon" id="pokemon1">
             <h2>{{ pokemon1.name | capitalize }}</h2>
             <img src="{{ pokemon1.sprite }}" alt="{{ pokemon1.name }}" />
-            <p>Total stats: {{ pokemon1.total_stats }}</p>
         </div>
 
         <div class="pokemon" id="pokemon2">
             <h2>{{ pokemon2.name | capitalize }}</h2>
             <img src="{{ pokemon2.sprite }}" alt="{{ pokemon2.name }}" />
-            <p>Total stats: {{ pokemon2.total_stats }}</p>
         </div>
     </div>
 


### PR DESCRIPTION
Address https://github.com/LAMaglan/PokeFightSimulator/issues/29

Here is the logic of base stats:
```python
def battle_simulator(pokemon1: Pokemon, pokemon2: Pokemon):
    if pokemon1.speed > pokemon2.speed:
        attacker = pokemon1
        defender = pokemon2
    else:
        attacker = pokemon2
        defender = pokemon1

    while pokemon1.hp > 0 and pokemon2.hp > 0:
        if attacker.attack > defender.defense:
            damage = attacker.attack - defender.defense
            defender.hp -= damage
        elif attacker.special_attack > defender.special_defense:
            damage = attacker.special_attack - defender.special_defense
            defender.hp -= damage
        attacker, defender = (
            defender,
            attacker,
        )  # Players switch roles for the next round

    if pokemon1.hp <= 0:
        return pokemon2.name
    else:
        return pokemon1.name
```


Also created a Pokemon class
Note: since inherits from BaseModel, and Pokemon is not defining the attributes as class attributes, 
have to use 
```python
class Config:
        allow_mutation = False        
```
