### PR TITLE
fix type advantage implementation

### DIFF
--- a/data/types.csv
+++ b/data/types.csv
@@ -1,4 +1,4 @@
-Types,Normal,Fire,Water,Electric,Grass,Ice,Fighting,Posion,Ground,Flying,Psychic,Bug,Rock,Ghost,Dragon,Dark,Steel,Fairy
+Types,Normal,Fire,Water,Electric,Grass,Ice,Fighting,Poison,Ground,Flying,Psychic,Bug,Rock,Ghost,Dragon,Dark,Steel,Fairy
 Normal,1,1,1,1,1,1,1,1,1,1,1,1,0.5,0,1,1,0.5,1
 Fire,1,0.5,0.5,1,2,2,1,1,1,1,1,2,0.5,1,0.5,1,2,1
 Water,1,2,0.5,1,0.5,1,1,1,2,1,1,1,2,1,0.5,1,1,1

--- a/main.py
+++ b/main.py
@@ -96,10 +96,15 @@ async def parse_types_csv():
         csv_reader = csv.reader(file)
         headers = next(csv_reader)
         for row in csv_reader:
+
+            # Lower case to match with pokeapi
             row_dict = {
-                header: float(value) for header, value in zip(headers[1:], row[1:])
+                header.lower(): float(value)
+                for header, value in zip(headers[1:], row[1:])
             }
-            type_advantages[row[0]] = row_dict
+            # Convert keys within the dictionary to lowercase
+            lowercase_key_row_dict = {k.lower(): v for k, v in row_dict.items()}
+            type_advantages[row[0].lower()] = lowercase_key_row_dict
 
 
 def clean_stat_names(stats: dict) -> dict:


### PR DESCRIPTION
The nested dict keys did not actually match the "keys" from pokeapi, so type advantages were actually never used (including separate typo for "poison")