### PR TITLE
custom tab names and clean up use of jinja blocks

### DIFF
--- a/templates/battle.html
+++ b/templates/battle.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 
+<head>
+    <title>{% block title %}Pokemon battle {% endblock title %}</title>
+</head>
+
 {% block content %}
 <h1>Battle Result</h1>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,7 +2,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>Pokemon Battle</title>
+    <title>{% block title %}Pokemon Battle{% endblock title %}</title>
     <style>
         #statsButton {
             margin-bottom: 20px;

--- a/templates/pokemon_stats.html
+++ b/templates/pokemon_stats.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 
+<head>
+    <title>{% block title %}Pokemon stats{% endblock title %}</title>
+</head>
+
 {% block content %}
 <h1>Pokemon Stats</h1>
 

--- a/templates/types.html
+++ b/templates/types.html
@@ -1,7 +1,10 @@
 {% extends "base.html" %}
 
+<head>
+    <title>{% block title %}Pokemon types{% endblock title %}</title>
+</head>
+
 {% block head %}
-{{ super() }}
 <link rel="stylesheet" href="/static/css/types_style.css">
 {% endblock %}
 


### PR DESCRIPTION
Removed superflous `{{ super() }}` (jinja templating) from previous commit.

Also, overriding blocks to have specific titles for browser tabs for each "page"